### PR TITLE
Add slight Internet Explorer (IE11) Rectification.

### DIFF
--- a/Rectify11.Phase2/Resources/rectify11.xml
+++ b/Rectify11.Phase2/Resources/rectify11.xml
@@ -37,7 +37,7 @@
 	<Patch Mui="firewallcontrolpanel.dll.mun" mask="ICONGROUP," HardlinkTarget="%sysresdir%\firewallcontrolpanel.dll.mun" />
 	<Patch Mui="gpedit.dll.mun" mask="ICONGROUP,|BITMAP," HardlinkTarget="%sysresdir%\gpedit.dll.mun" />
 	<Patch Mui="icsigd.dll.mun" mask="ICONGROUP," HardlinkTarget="%sysresdir%\icsigd.dll.mun" />
-	<Patch Mui="ieframe.dll.mun" mask="ICONGROUP," HardlinkTarget="%sysresdir%\ieframe.dll.mun" />
+	<Patch Mui="ieframe.dll.mun" mask="ICONGROUP,|IMAGE," HardlinkTarget="%sysresdir%\ieframe.dll.mun" />
 	<Patch Mui="imageres.dll.mun" mask="ICONGROUP," HardlinkTarget="%sysresdir%\imageres.dll.mun" />
 	<Patch Mui="imagesp1.dll.mun" mask="ICONGROUP," HardlinkTarget="%sysresdir%\imagesp1.dll.mun" />
 	<Patch Mui="inetcpl.cpl.mun" mask="ICONGROUP," HardlinkTarget="%sysresdir%\inetcpl.cpl.mun" />

--- a/Rectify11Installer/Core/rectify11.xml
+++ b/Rectify11Installer/Core/rectify11.xml
@@ -37,7 +37,7 @@
 	<Patch Mui="firewallcontrolpanel.dll.mun" mask="ICONGROUP," HardlinkTarget="%sysresdir%\firewallcontrolpanel.dll.mun" />
 	<Patch Mui="gpedit.dll.mun" mask="ICONGROUP,|BITMAP," HardlinkTarget="%sysresdir%\gpedit.dll.mun" />
 	<Patch Mui="icsigd.dll.mun" mask="ICONGROUP," HardlinkTarget="%sysresdir%\icsigd.dll.mun" />
-	<Patch Mui="ieframe.dll.mun" mask="ICONGROUP," HardlinkTarget="%sysresdir%\ieframe.dll.mun" />
+	<Patch Mui="ieframe.dll.mun" mask="ICONGROUP,|IMAGE," HardlinkTarget="%sysresdir%\ieframe.dll.mun" />
 	<Patch Mui="imageres.dll.mun" mask="ICONGROUP," HardlinkTarget="%sysresdir%\imageres.dll.mun" />
 	<Patch Mui="imagesp1.dll.mun" mask="ICONGROUP," HardlinkTarget="%sysresdir%\imagesp1.dll.mun" />
 	<Patch Mui="inetcpl.cpl.mun" mask="ICONGROUP," HardlinkTarget="%sysresdir%\inetcpl.cpl.mun" />


### PR DESCRIPTION
This pull request adds the slightly Rectified Internet Explorer (IE11), that i made some time ago, preview can be seen below:
![image](https://github.com/Rectify11/Installer/assets/95425619/1b3ec869-11f5-4dfb-a46a-e7593c45c678)
![image](https://github.com/Rectify11/Installer/assets/95425619/9b6ed6e6-3fa5-4d57-998c-b490f92abe73)
![image](https://github.com/Rectify11/Installer/assets/95425619/bc2176b4-0ff8-416f-9f26-0357b1a4dd90)
